### PR TITLE
Include tar in Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM docker:17.06.0-ce-git
 
-RUN apk add --no-cache make py-pip && pip install docker-compose
+RUN apk add --no-cache make py-pip tar && pip install docker-compose


### PR DESCRIPTION
`tar` is required in CircleCI pipelines for restoring workspaces.