### PR TITLE
Delete pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM docker:17.06.0-ce-git
 
-RUN apk add --no-cache make py-pip tar && pip install docker-compose
+RUN apk add --no-cache make py-pip tar && pip install docker-compose && apk del --no-cache py-pip


### PR DESCRIPTION
The image should stay as small as possible, and pip is required only to install docker-compose.