### PR TITLE
Fixed apk update issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ RUN set -exu && \
 apk add --update bash ca-certificates curl git make py-pip tar jq && \
 pip install docker-compose && \
 rm -rf ~/* /var/cache/* && \
-mkdir -p /var/cache/docker/ /usr/local/src/
+mkdir -p /var/cache/apk/ /var/cache/docker/ /usr/local/src/
 
 WORKDIR /usr/local/src


### PR DESCRIPTION
### Issue

Error during execution of `apk update`

```
# bash-4.4# apk update
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/main/x86_64/APKINDEX.tar.gz
ERROR: http://dl-cdn.alpinelinux.org/alpine/v3.7/main: Bad file descriptor
WARNING: Ignoring APKINDEX.70c88391.tar.gz: Bad file descriptor
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/community/x86_64/APKINDEX.tar.gz
ERROR: http://dl-cdn.alpinelinux.org/alpine/v3.7/community: Bad file descriptor
WARNING: Ignoring APKINDEX.5022a8a2.tar.gz: Bad file descriptor
2 errors; 37 distinct packages available
```